### PR TITLE
音乐库界面添加歌单分类tab

### DIFF
--- a/entry/src/main/ets/component/PlaylistList.ets
+++ b/entry/src/main/ets/component/PlaylistList.ets
@@ -1,5 +1,5 @@
 import { LazyData } from "@pie/lazy-data";
-import { Playlist, SourceConfig } from "../type/Adapter";
+import { ID, Playlist, SourceConfig } from "../type/Adapter";
 import { ToastUtil } from '@pura/harmony-utils';
 import { SourceAdapter } from '../adapter';
 import { StyleConstants } from '../constants/StyleConstants';
@@ -18,6 +18,7 @@ export struct PlaylistList {
   @State dataSource: LazyData<Playlist> = new LazyData<Playlist>(this.playlists);
   @Prop adapters: SourceConfig[] = []
   @Link sIndex: number
+  @Link subTitleIndex: number
 
   build() {
     Column() {
@@ -32,14 +33,32 @@ export struct PlaylistList {
         .height(StyleConstants.FULL_HEIGHT)
         .justifyContent(FlexAlign.Center)
       } else {
-        LazyForEach(this.dataSource, (playlist: Playlist, pIndex) => {
-          if(this.judgeSourceByDataSourceId(playlist)){
-            ListItem(){
-              this.PlaylistItem(playlist)
-            }
+        // 版本三：歌单分类项
+        Tabs({ index: this.subTitleIndex }) {
+          TabContent(){
+            this.TabContentList(this.playlists, 0)
           }
-        })
-        // 歌单列表展示
+          TabContent(){
+            this.TabContentList(this.playlists, 1)
+          }
+          TabContent(){
+            this.TabContentList(this.playlists, 2)
+          }
+        }
+        .scrollable(false)
+        .edgeEffect(EdgeEffect.Spring)
+        .barHeight(0)
+
+        // 版本二：不包含歌单分类项（暂不删除，万一以后用的上）
+        // LazyForEach(this.dataSource, (playlist: Playlist, pIndex) => {
+        //   if(this.judgeSourceByDataSourceId(playlist)){
+        //     ListItem(){
+        //       this.PlaylistItem(playlist)
+        //     }
+        //   }
+        // })
+
+        // 版本一：歌单列表展示（暂不删除，万一以后用的上）
         // Tabs({ index: this.sIndex }){
         //   ForEach(this.adapters, (adapter: SourceConfig, SIndex) => {
         //     TabContent(){
@@ -81,8 +100,22 @@ export struct PlaylistList {
     .expandSafeArea()
   }
 
-  judgeSourceByDataSourceId(playlist: Playlist): boolean {
-    const exists = this.showAdapters.some(adapter => adapter.id === playlist.source?.id)
+  judgeSourceByDataSourceId(playlist: Playlist, index: number): boolean {
+    let exists: boolean = false
+    const showAdapterIDs: ID[] = this.showAdapters.map(adapter => adapter.id)
+    if(showAdapterIDs.includes(playlist.source?.id as ID)){
+      switch(index){
+        case 0:
+          exists = true
+          break
+        case 1:
+          exists = playlist.creator?.id === playlist.source?.auth?.user?.id
+          break
+        case 2:
+          exists = playlist.creator?.id !== playlist.source?.auth?.user?.id
+          break
+      }
+    }
     return exists
   }
 
@@ -93,6 +126,33 @@ export struct PlaylistList {
       }
     }
     return false
+  }
+
+  @Builder
+  TabContentList(playLists: Playlist[], index: number){
+    List(){
+      ListItem(){
+        Row().height(12)
+      }
+      ForEach(playLists, (playlist: Playlist) => {
+        if(this.judgeSourceByDataSourceId(playlist, index)){
+          ListItem(){
+            this.PlaylistItem(playlist)
+          }
+        }
+      })
+      ListItem(){
+        Column()
+          .height(StyleConstants.PLAYER_CONTROL_HEIGHT + 32 + px2vp(this.bottomRect))
+      }
+    }
+    .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_FIRST})
+    .width('100%')
+    .height('100%')
+    .listDirection(Axis.Vertical)
+    .edgeEffect(EdgeEffect.Spring)
+    .scrollBar(BarState.Off)
+    .backgroundColor($r('app.color.page_background'))
   }
 
   @Builder
@@ -202,4 +262,5 @@ export struct PlaylistList {
       }
     ]
   }
+
 }

--- a/entry/src/main/ets/component/TitleHeader.ets
+++ b/entry/src/main/ets/component/TitleHeader.ets
@@ -5,6 +5,7 @@ export struct TitleHeader {
   @Consume('NavPathStack') pageStack: NavPathStack;
   @Prop title: ResourceStr = $r("app.string.homepage")
   @BuilderParam rightContent: () => void;
+  @BuilderParam midContent: () => void;
   @State isFirstPage: boolean = true
   @Prop backActive: boolean = false
 
@@ -57,7 +58,12 @@ export struct TitleHeader {
             .fontWeight(StyleConstants.FONT_WEIGHT_SEVEN)
             .fontSize($r('app.float.title_font_size'))
             .maxLines(1)
-          // 占位，把“返回”挤出屏幕
+
+          // 自定义左侧
+          if(this.midContent){
+            this.midContent()
+          }
+          // 自定义右侧
           if (this.rightContent) {
             this.rightContent()
           }

--- a/entry/src/main/ets/view/Library.ets
+++ b/entry/src/main/ets/view/Library.ets
@@ -91,7 +91,7 @@ struct Library {
         Row()
           .width(this.capsuleWidth)
           .height(10)
-          .backgroundColor('#ad9e5f')
+          .backgroundColor($r('app.color.title_emphasis_color'))
           .borderRadius(5)
           .margin({ bottom: -20})
           .scale({ x: this.scaleX, y: this.scaleY })

--- a/entry/src/main/ets/view/Library.ets
+++ b/entry/src/main/ets/view/Library.ets
@@ -91,12 +91,11 @@ struct Library {
         Row()
           .width(this.capsuleWidth)
           .height(10)
-          .backgroundColor('#9ad25858')
+          .backgroundColor('#ad9e5f')
           .borderRadius(5)
           .margin({ bottom: -20})
           .scale({ x: this.scaleX, y: this.scaleY })
           .shadow(ShadowStyle.OUTER_DEFAULT_XS)
-          .backgroundBlurStyle(BlurStyle.Regular)
       }
       .height(35)
       .layoutWeight(1)

--- a/entry/src/main/ets/view/Library.ets
+++ b/entry/src/main/ets/view/Library.ets
@@ -6,12 +6,12 @@ import { SourceAdapter } from "../adapter";
 import { PlaylistList } from "../component/PlaylistList";
 import { SlideDownControl } from "../util/SlideDownController";
 import { MiniPlaybackControl } from "../component/MiniPlaybackControl";
-import { LogUtil } from "@pura/harmony-utils";
 import FormUtils from "../util/FormUtils"
 import { cover } from "../util/AdapterHelper";
 import { promptAction } from "@kit.ArkUI";
 import { PreferencesCache } from "../util/PreferenceCache";
-import { ToastUtil } from "@pura/harmony-utils";
+
+const subTitles: string[] = ['所有', '自建', '收藏']
 
 @Builder
 export function LibraryBuilder(){
@@ -33,7 +33,18 @@ struct Library {
   @StorageProp("user_data_source") adapters: SourceConfig[] = []
   @StorageLink("show_user_data_source") showAdapters: SourceConfig[] = PreferencesCache.getShowUserDataSource()
   @State sIndex: number = 0
+  @State @Watch('onChangeSubTitleIndex') subTitleIndex: number = 0
   @State isExpanded: boolean = false
+  @State capsuleOffset: number = 0
+  @State capsuleWidth: number = 0
+  @State titleWidths: number[] = []
+  private readonly BUTTON_GAP: number = 15
+  @State scaleX: number = 0.9
+  @State scaleY: number = 1.0
+
+  onChangeSubTitleIndex(){
+    this.updateCapsulePosition(this.subTitleIndex)
+  }
 
   onMenuIconClick(index: number) {
     if (index === 0) {
@@ -66,8 +77,58 @@ struct Library {
       backActive: this.currentIndex === 0,
       rightContent: () => {
         this.ButtonS()
+      },
+      midContent: () => {
+        this.TabsTitles()
       }
     })
+  }
+
+  @Builder
+  TabsTitles(){
+    Stack(){
+      Row(){
+        Row()
+          .width(this.capsuleWidth)
+          .height(10)
+          .backgroundColor('#9ad25858')
+          .borderRadius(5)
+          .margin({ bottom: -20})
+          .scale({ x: this.scaleX, y: this.scaleY })
+          .shadow(ShadowStyle.OUTER_DEFAULT_XS)
+          .backgroundBlurStyle(BlurStyle.Regular)
+      }
+      .height(35)
+      .layoutWeight(1)
+      .align(Alignment.BottomStart)
+      .padding({ left: this.capsuleOffset })
+      .animation({ duration: 500, curve: Curve.FastOutSlowIn })
+
+      Row({ space: 15 }){
+        ForEach(subTitles, (str: string, index: number) => {
+          Text(str)
+            .fontColor($r('app.color.text_secondary'))
+            .fontWeight(FontWeight.Bold)
+            .fontSize('20fp')
+            .backgroundColor('transparent')
+            .onClick(() => this.updateCapsulePosition(index))
+            .onAreaChange((_, area) => {
+              this.titleWidths[index] = area.width as number
+              if (index === this.subTitleIndex) {
+                this.capsuleWidth = area.width as number
+              }
+            })
+            .margin({ bottom: -5 })
+        })
+      }
+      .height(35)
+      .align(Alignment.BottomStart)
+      .layoutWeight(1)
+    }
+    .height(35)
+    .layoutWeight(1)
+    .padding({ left: 20 })
+    .align(Alignment.BottomStart)
   }
 
   @Builder
@@ -139,6 +200,29 @@ struct Library {
       bottom: 5
     })
     .height(40)
+  }
+
+  private updateCapsulePosition(index: number) {
+    let offset = 0
+    for (let i = 0; i < index; i++) {
+      offset += (this.titleWidths[i] || 0) + this.BUTTON_GAP
+    }
+
+    animateTo({ duration: 150, curve: Curve.EaseOut }, () => {
+      this.scaleX = 0.4
+      this.scaleY = 1.3
+    })
+
+    animateTo({ duration: 200, curve: Curve.EaseInOut }, () => {
+      this.capsuleOffset = offset
+    })
+
+    animateTo({ duration: 150, curve: Curve.EaseIn }, () => {
+      this.scaleX = 0.9
+      this.scaleY = 1
+      this.capsuleWidth = this.titleWidths[index]
+      this.subTitleIndex = index
+    })
   }
 
   private getBackgroundColor(sourceConfig: SourceConfig) {
@@ -267,6 +351,7 @@ struct Library {
                 PlaylistList({
                   playlists: [...this.playlists],
                   sIndex: this.sIndex,
+                  subTitleIndex: this.subTitleIndex,
                   adapters: this.adapters,
                   onPlaylistSelected: (item: Playlist) => {
                     PushPathHelper.pushPath(this.pageStack, "Playlist", async () => {

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -996,7 +996,7 @@ struct Playing {
       .height(StyleConstants.FULL_HEIGHT)
       .expandSafeArea()
     }
-    .systemTransition(NavigationSystemTransitionType.SLIDE_BOTTOM)
+    .systemTransition(NavigationSystemTransitionType.FADE)
     .hideToolBar(true)
     .hideTitleBar(true)
     .backgroundColor($r('app.color.page_background'))

--- a/entry/src/main/resources/base/element/color.json
+++ b/entry/src/main/resources/base/element/color.json
@@ -123,6 +123,10 @@
     {
       "name": "item_title_font",
       "value": "#E6000000"
+    },
+    {
+      "name": "title_emphasis_color",
+      "value": "#fecc11"
     }
   ]
 }

--- a/entry/src/main/resources/dark/element/color.json
+++ b/entry/src/main/resources/dark/element/color.json
@@ -119,6 +119,10 @@
     {
       "name": "card_background_two",
       "value": "#242424"
+    },
+    {
+      "name": "title_emphasis_color",
+      "value": "#fecc11"
     }
   ]
 }


### PR DESCRIPTION
音乐库界面添加歌单分类tab，由于分页需要使用Tabs，懒加载会在非第一页Tab失效，暂时改为ForEach，如后续有大量歌单问题，再行优化