### PR TITLE
perf: 减少大歌单页的内存占用，提高加载速度（减少轮播图的持有，由99->30）

### DIFF
--- a/entry/src/main/ets/component/AlbumCoversCarousel.ets
+++ b/entry/src/main/ets/component/AlbumCoversCarousel.ets
@@ -27,7 +27,7 @@ export struct AlbumCoversCarousel {
   private allSongs: Song[][] = [];
 
   // 定时器ID
-  private timer: number = 0;
+  private timer: number = -1;
   // 容器宽度
   private containerWidth: number = 0;
 
@@ -43,9 +43,9 @@ export struct AlbumCoversCarousel {
 
   // 清除定时器
   private clearTimer() {
-    if (this.timer !== 0) {
+    if (this.timer !== -1) {
       clearInterval(this.timer);
-      this.timer = 0;
+      this.timer = -1;
     }
   }
 
@@ -58,7 +58,7 @@ export struct AlbumCoversCarousel {
     this.allSongs = Array(this.rows).fill(0).map(() => []);
 
     // 限制最多使用99首歌曲
-    const songCount = Math.min(this.songs.length, 99);
+    const songCount = Math.min(this.songs.length, 30);
 
     // 按照指定顺序排列歌曲
     for (let i = 0; i < songCount; i++) {
@@ -75,7 +75,7 @@ export struct AlbumCoversCarousel {
     // 设置计时器
     this.timer = setInterval(() => {
       // 计算移动距离
-      const moveDistance = this.scrollSpeed / 60;
+      const moveDistance = this.scrollSpeed / 150;
 
       // 更新滚动位置
       this.scrollPosition -= moveDistance;

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -108,8 +108,11 @@ export default class EntryAbility extends UIAbility {
       AppStorage.setOrCreate('bottomRect', windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_SYSTEM).bottomRect.height);
       // 监听避让高度变化
       windowClass.on('avoidAreaChange', (avoidArea) => {
-        AppStorage.setOrCreate('topRect', avoidArea.area.topRect.height);
-        AppStorage.setOrCreate('bottomRect', avoidArea.area.bottomRect.height);
+        if (avoidArea.type === window.AvoidAreaType.TYPE_SYSTEM) {
+          AppStorage.setOrCreate('topRect', avoidArea.area.topRect.height);
+        } else if (avoidArea.type === window.AvoidAreaType.TYPE_NAVIGATION_INDICATOR) {
+          AppStorage.setOrCreate('bottomRect', avoidArea.area.bottomRect.height);
+        }
       });
     });
     windowStage.loadContent('pages/Index', (err) => {

--- a/entry/src/main/ets/util/LyricsManager.ets
+++ b/entry/src/main/ets/util/LyricsManager.ets
@@ -37,6 +37,7 @@ class LyricsManager {
     this.originalLyrics = this.song?.meta?.lyric?.normal ?? ''
     this.translatedLyrics = this.song?.meta?.lyric?.translation ?? ''
     this.transliteratedLyrics = this.song?.meta?.lyric?.transliteration ?? ''
+    AppStorage.setOrCreate<string>('test_index', this.song?.name + ' - ' + this.song?.artists[0].name)
     this.parseLyrics()
     this.setLyricsInterval()
   }

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -522,7 +522,7 @@ struct Playing {
       if (this.isPlaying && this.currentTime < (this.song?.duration || 0)) {
         this.currentTime = player.currentTime;
       }
-    }, 1000)
+    }, 300)
 
     // 初始化监听
     EventHelper.subscribeLoopMode((mode: number) => {
@@ -663,11 +663,12 @@ struct Playing {
         value: this.currentTime,
         max: this.song?.duration || 0,
         step: 1,
-        style: SliderStyle.NONE
+        style: SliderStyle.InSet
       })
-        .trackThickness(this.isProgressBarExpanded ? 8 : 4+weight)
-        .selectedColor(Color.White)
+        .trackThickness(this.isProgressBarExpanded ? 12 : 8+weight)
+        .selectedColor('rgba(202, 202, 202, 1.00)')
         .trackColor('rgba(255, 255, 255, 0.3)')// 半透明背景
+        .blockColor('rgba(255, 255, 255, 1.00)')
         .width(StyleConstants.FULL_WIDTH)
         .height(32)// 固定高度以保持布局稳定
         .animation({
@@ -725,7 +726,7 @@ struct Playing {
   }
 
   private coverWidth = new BreakPointType({
-    sm: '70%',
+    sm: '90%',
     md: '60%',
     lg: '50%'
   })
@@ -1100,7 +1101,7 @@ struct Playing {
         .width(this.coverWidth.getValue(this.currentBreakpoint))
         .aspectRatio(1)
         .borderRadius(24)
-        .margin({ top: 36 })
+        .margin({ bottom: 16 })
           // .geometryTransition('song-cover', { follow: true })
         .transition(TransitionEffect.OPACITY)
         .onClick(() => {

--- a/entry/src/main/ets/view/Playlist.ets
+++ b/entry/src/main/ets/view/Playlist.ets
@@ -330,7 +330,7 @@ export struct PlayList {
           coverSize: 56,
           scrollSpeed: 60,
           rows: 1,
-          songs: this.playlist?.songs.slice(0, 99) || [],
+          songs: this.playlist?.songs.slice(0, 30) || [],
           onCoverClick: (song: Song, index: number) => {
             this.handleCoverClick(song, index);
           }


### PR DESCRIPTION
1. [perf: 减少大歌单页的内存占用，提高加载速度（减少轮播图的持有，由99->30）](https://github.com/Edge-Music/Core/pull/72/commits/1a890b19ff185908dad480d898e7d1a63b4d7477)
2. [feat: 画中画歌词切换下一首时先展示 歌名-歌手](https://github.com/Edge-Music/Core/pull/72/commits/e21e3293ce762a542b5cf3aee8bee5c83ae887a5)
3. [style: 播放页进度条样式调整，封面大小调整](https://github.com/Edge-Music/Core/pull/72/commits/afe2f8c1865d314986f2f0b3e6156bf89d8f5653)
4. [fix: 避让区获取高度修复，原逻辑会覆盖状态栏高度错误为0](https://github.com/Edge-Music/Core/pull/72/commits/026c0212210c52b3479917c357c3ee36356b201a)